### PR TITLE
ci(release): set Cargo.toml version from tag before publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags: ["*"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  crates_io_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Set version in Cargo.toml from tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG_NAME#v}"
+          echo "Setting version to ${VERSION} from tag ${TAG_NAME}"
+          sed -i -E 's/^version = ".*"/version = "'"${VERSION}"'"/' Cargo.toml
+          echo "Updated Cargo.toml version line:"
+          grep '^version = ' Cargo.toml || true
+
+      - name: cargo login
+        run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+
+      - name: cargo publish
+        run: cargo publish --all-features --allow-dirty

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "envtest"
+readme = "README.md"
+repository = "https://github.com/kube-rs/envtest"
+description = "A lightweight, type‑safe wrapper around the Kubernetes `envtest` Go package that lets you spin up a temporary control plane from Rust."
 version = "0.1.0"
 edition = "2024"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
- Extract tag name and strip leading "v" (e.g., v1.2.3 -> 1.2.3)
- Publish with `--allow-dirty`; no commit back to repo