### PR TITLE
pin kube version to latest for the `kube` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ rust2go = { version = "0.4.3", optional = true}
 serde = "1"
 serde_json = "1"
 thiserror = "2"
-k8s-openapi = { version = ">= 0", features = ["latest"], optional = true }
-kube = { version = ">= 1", optional = true }
+k8s-openapi = { version = "0.28", features = ["latest"], optional = true }
+kube = { version = "4", optional = true }
 smol = "2.0.2"
 
 [features]
@@ -24,9 +24,9 @@ _docsrs = []
 default = ["kube", "r2g"]
 
 [dev-dependencies]
-schemars = ">= 1"
-k8s-openapi = { version = ">= 0", features = ["latest"]}
-kube = { version = ">= 1", features = ["derive"] }
+schemars = "1.2.0"
+k8s-openapi = { version = "0.28", features = ["latest"]}
+kube = { version = "4", features = ["derive"] }
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4.5"
 seq-macro = "0.3"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let env = Environment::default();
 
     // 2. Spin up a temporary control plane
-    let server = env.create()?;
+    let server = env.create().await?;
 
     // 3. Retrieve a strongly‑typed kubeconfig
     let kubeconfig = server.kubeconfig()?;
@@ -86,9 +86,9 @@ use envtest::Environment;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut env = Environment::default();
-    env.binary_assets_settings.download_binary_assets_version = Some("1.32.0".to_string());
+    env.binary_assets_settings.download_binary_assets_version = Some("1.36.0".to_string());
     env.binary_assets_settings.binary_assets_directory = Some(".cache/envtest".to_string());
-    let server = env.create()?;
+    let server = env.create().await?;
     Ok(())
 }
 ```
@@ -104,7 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let env = Environment::default()
         .with_crds(crd)?;
 
-    let server = env.create()?;
+    let server = env.create().await?;
     Ok(())
 }
 ```
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 The `Server` implements `Drop`, but you can destroy it manually:
 
 ```rust
-let server = env.create()?;
+let server = env.create().await?;
 server.destroy()?;
 ```
 
@@ -130,7 +130,7 @@ use k8s_openapi::api::core::v1::Namespace;
 
 #[tokio::test]
 async fn work_with_namespace_with_kube_client() -> Result<(), Box<dyn std::error::Error>> {
-    let server = Environment::default().create()?;
+    let server = Environment::default().create().await?;
     let namespaces: Api<Namespace> = Api::all(server.client()?);
     namespaces
         .create(

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module envtest
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/ihciah/rust2go v0.0.0-20260204100215-11857866675c


### PR DESCRIPTION
Switch to recommended model for maintaining `kube` dependency, pinned to latest https://kube.rs/upgrading/#upgrading

Fixes #69 