### PR TITLE
remove features from k8s-openapi dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,12 +8,12 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go/go.mod'
-      - run: cargo build
-      - run: cargo t
+      - run: K8S_OPENAPI_ENABLED_VERSION=latest cargo build
+      - run: K8S_OPENAPI_ENABLED_VERSION=latest cargo t
   docs-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
-      - run: cargo docs-rs
+      - run: K8S_OPENAPI_ENABLED_VERSION=latest cargo docs-rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust2go = { version = "0.4.3", optional = true}
 serde = "1"
 serde_json = "1"
 thiserror = "2"
-k8s-openapi = { version = "0.28", features = ["latest"], optional = true }
+k8s-openapi = { version = "0.28", optional = true }
 kube = { version = "4", optional = true }
 smol = "2.0.2"
 


### PR DESCRIPTION
Library crates must not enable k8s-openapi features. The eventual app/operator needs to be able to select their own version.
See <https://github.com/Arnavion/k8s-openapi/blob/b2c839b8b1828e9035ff8467cdac87756190aa4e/src/lib.rs#L75>.

resolves #73 